### PR TITLE
User Authentication and Survey Closure Mechanism related to issue #19 and issue #10

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$" libraries="{jquery-3.6.0}" />
-  </component>
-</project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,24 @@
             <artifactId>org.eclipse.persistence.jpa</artifactId>
             <version>4.0.2</version>
         </dependency>
+
+        <!-- Spring Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- Thymeleaf Extras for Spring Security -->
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+        </dependency>
+
+        <!-- Password Encoder -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/MiniSurveyMonkeyApplication.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/MiniSurveyMonkeyApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class MiniSurveyMonkeyApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(MiniSurveyMonkeyApplication.class, args);
     }

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/config/SecurityConfig.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/config/SecurityConfig.java
@@ -1,0 +1,80 @@
+package com.github.adhambadawi.minisurveymonkey.config;
+
+import com.github.adhambadawi.minisurveymonkey.service.CustomUserDetailsService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public CustomUserDetailsService userDetailsService() {
+        return new CustomUserDetailsService();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers(new AntPathRequestMatcher("/h2-console/**"))
+                )
+                .headers(headers -> headers
+                        .frameOptions(frameOptions -> frameOptions.sameOrigin())
+                )
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(new AntPathRequestMatcher("/"),
+                                new AntPathRequestMatcher("/register"),
+                                new AntPathRequestMatcher("/login"),
+                                new AntPathRequestMatcher("/css/**"),
+                                new AntPathRequestMatcher("/js/**"),
+                                new AntPathRequestMatcher("/h2-console/**"))
+                        .permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/survey/new"),
+                                new AntPathRequestMatcher("/survey/*/close"))
+                        .hasRole("USER")
+                        .anyRequest()
+                        .authenticated()
+                )
+                .formLogin(form -> form
+                        .loginPage("/login")
+                        .defaultSuccessUrl("/", true)
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .permitAll()
+                );
+        return http.build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web
+                .ignoring()
+                .requestMatchers(new AntPathRequestMatcher("/h2-console/**"));
+    }
+
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.authenticationProvider(authenticationProvider());
+    }
+}

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/controller/ApplicationController.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/controller/ApplicationController.java
@@ -2,37 +2,44 @@ package com.github.adhambadawi.minisurveymonkey.controller;
 
 import com.github.adhambadawi.minisurveymonkey.model.Question;
 import com.github.adhambadawi.minisurveymonkey.model.Survey;
+import com.github.adhambadawi.minisurveymonkey.model.User;
 import com.github.adhambadawi.minisurveymonkey.repository.QuestionRepository;
 import com.github.adhambadawi.minisurveymonkey.service.SurveyService;
+import com.github.adhambadawi.minisurveymonkey.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.*;
-
+import java.security.Principal;
 import java.util.List;
+import java.util.Optional;
 
 
 @Controller
 public class ApplicationController {
 
     private final SurveyService surveyService;
+    private final UserService userService;
 
     @Autowired
-    public ApplicationController(SurveyService surveyService, QuestionRepository questionRepository) {
+    public ApplicationController(SurveyService surveyService, UserService userService) {
         this.surveyService = surveyService;
+        this.userService = userService;
     }
 
     @GetMapping("/survey/new")
-    public String showSurveyForm(Model model) {
+    public String showSurveyForm(Model model, Principal principal) {
         model.addAttribute("survey", new Survey());
         model.addAttribute("question", new Question());
         return "surveyForm";
     }
 
     @PostMapping("/survey/new")
-    public String submitSurveyForm(@ModelAttribute Survey survey) throws Exception {
+    public String submitSurveyForm(@ModelAttribute Survey survey, Principal principal) throws Exception {
+        // Get the logged-in user
+        User creator = userService.findByUsername(principal.getName());
+        survey.setCreator(creator);
+
         //Remove any questions with input issues
         List<Question> validQuestions = survey.getQuestions().stream()
                 .filter(question -> question != null && question.getText() != null && !question.getText().trim().isEmpty())
@@ -47,9 +54,41 @@ public class ApplicationController {
     }
 
     @GetMapping("/")
-    public String index() {
+    public String index(Model model, Principal principal) {
+        List<Survey> surveys = surveyService.getAllSurveys();
+        model.addAttribute("surveys", surveys);
+        model.addAttribute("user", principal != null ? principal.getName() : null);
         return "index";
     }
 
+    @PostMapping("/survey/{id}/close")
+    public String closeSurvey(@PathVariable Long id, Principal principal) {
+        Optional<Survey> optionalSurvey = surveyService.getSurveyById(id);
+        if (optionalSurvey.isPresent()) {
+            Survey survey = optionalSurvey.get();
+            // Check if the logged-in user is the creator
+            if (survey.getCreator().getUsername().equals(principal.getName())) {
+                survey.setClosed(true);
+                surveyService.updateSurvey(survey);
+                return "redirect:/survey/" + id + "/details";
+            } else {
+                // Unauthorized access
+                return "error/403";
+            }
+        } else {
+            return "redirect:/";
+        }
+    }
 
+    @GetMapping("/survey/{id}/details")
+    public String surveyDetails(@PathVariable Long id, Model model) {
+        Optional<Survey> optionalSurvey = surveyService.getSurveyById(id);
+        if (optionalSurvey.isPresent()) {
+            Survey survey = optionalSurvey.get();
+            model.addAttribute("survey", survey);
+            return "surveyDetails";
+        } else {
+            return "redirect:/";
+        }
+    }
 }

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/controller/UserController.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/controller/UserController.java
@@ -1,0 +1,37 @@
+package com.github.adhambadawi.minisurveymonkey.controller;
+
+import com.github.adhambadawi.minisurveymonkey.model.User;
+import com.github.adhambadawi.minisurveymonkey.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+
+@Controller
+public class UserController {
+
+    @Autowired
+    private UserService userService;
+
+    @GetMapping("/register")
+    public String showRegistrationForm(Model model) {
+        model.addAttribute("user", new User());
+        return "register";
+    }
+
+    @PostMapping("/register")
+    public String registerUser(@ModelAttribute User user, Model model) {
+        if (userService.findByUsername(user.getUsername()) != null) {
+            model.addAttribute("error", "Username already exists");
+            return "register";
+        }
+        userService.registerUser(user);
+        return "redirect:/login?success";
+    }
+
+    @GetMapping("/login")
+    public String showLoginForm() {
+        return "login";
+    }
+}

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/model/User.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/model/User.java
@@ -14,6 +14,7 @@ public class User {
 
     private String username;
     private String password;
+    private String role = "ROLE_USER";
 
     @OneToMany(mappedBy = "creator", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Survey> surveys = new ArrayList<>();
@@ -66,5 +67,13 @@ public class User {
     public void removeSurvey(Survey survey) {
         surveys.remove(survey);
         survey.setCreator(null);
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
     }
 }

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/service/CustomUserDetailsService.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/service/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.github.adhambadawi.minisurveymonkey.service;
+
+import com.github.adhambadawi.minisurveymonkey.model.User;
+import com.github.adhambadawi.minisurveymonkey.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username);
+        if (user == null) {
+            throw new UsernameNotFoundException("User not found");
+        }
+        return new org.springframework.security.core.userdetails.User(user.getUsername(),
+                user.getPassword(),
+                java.util.Collections.singletonList(new org.springframework.security.core.authority.SimpleGrantedAuthority(user.getRole())));
+    }
+}

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/service/UserService.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/service/UserService.java
@@ -1,0 +1,26 @@
+package com.github.adhambadawi.minisurveymonkey.service;
+
+import com.github.adhambadawi.minisurveymonkey.model.User;
+import com.github.adhambadawi.minisurveymonkey.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    public User registerUser(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        return userRepository.save(user);
+    }
+
+    public User findByUsername(String username) {
+        return userRepository.findByUsername(username);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,11 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 
+# Disable CSRF for H2 Console Access
+spring.security.filter.dispatcher-types=REQUEST,FORWARD,ASYNC,ERROR
+
+logging.level.org.springframework.security=DEBUG
+
 # Thymeleaf template location and settings
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,12 +1,30 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Survey Application</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body>
 <h1>Welcome to the Survey Application</h1>
-<a href="/survey/new">Create a Survey</a>
+<p th:if="${user != null}">
+    Logged in as <strong th:text="${user}"></strong> |
+    <a th:href="@{/logout}">Logout</a>
+</p>
+<p th:if="${user == null}">
+    <a th:href="@{/login}">Login</a> |
+    <a th:href="@{/register}">Register</a>
+</p>
+<a th:href="@{/survey/new}">Create a Survey</a>
+
+<h2>Available Surveys</h2>
+<ul>
+    <li th:each="survey : ${surveys}">
+        <span th:text="${survey.title}"></span> -
+        <span th:text="${survey.isClosed} ? 'Closed' : 'Open'"></span>
+        <!-- Link to participate if the survey is open -->
+        <a th:if="!${survey.isClosed}" th:href="@{/survey/{id}/participate(id=${survey.id})}">Participate</a>
+    </li>
+</ul>
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<form th:action="@{/login}" method="post">
+    <!-- CSRF Token -->
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+
+    <label>Username:</label>
+    <input type="text" name="username"/><br/>
+    <label>Password:</label>
+    <input type="password" name="password"/><br/>
+    <button type="submit">Login</button>
+</form>
+<p th:if="${param.error}">
+    Invalid username or password.
+</p>
+<p th:if="${param.logout}">
+    You have been logged out.
+</p>
+<p>
+    Don't have an account? <a th:href="@{/register}">Register here</a>.
+</p>
+</body>
+</html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+</head>
+<body>
+<h1>Register</h1>
+<form th:action="@{/register}" th:object="${user}" method="post">
+    <!-- CSRF Token -->
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+
+    <label>Username:</label>
+    <input type="text" th:field="*{username}" required/><br/>
+    <label>Password:</label>
+    <input type="password" th:field="*{password}" required/><br/>
+    <button type="submit">Register</button>
+</form>
+<p th:if="${error}">
+    <span th:text="${error}"></span>
+</p>
+<p>
+    Already have an account? <a th:href="@{/login}">Login here</a>.
+</p>
+</body>
+</html>

--- a/src/main/resources/templates/surveyDetails.html
+++ b/src/main/resources/templates/surveyDetails.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Survey Details</title>
+</head>
+<body>
+<h1 th:text="${survey.title}">Survey Title</h1>
+<p>Status: <span th:text="${survey.isClosed} ? 'Closed' : 'Open'"></span></p>
+
+<h2>Questions</h2>
+<ul>
+    <li th:each="question : ${survey.questions}">
+        <span th:text="${question.text}"></span>
+    </li>
+</ul>
+
+<!-- Only show close button if the survey is open -->
+<form th:if="!${survey.isClosed}" th:action="@{/survey/{id}/close(id=${survey.id})}" method="post">
+    <!-- CSRF Token -->
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+    <button type="submit">Close Survey</button>
+</form>
+
+<a th:href="@{/}">Back to Home</a>
+</body>
+</html>

--- a/src/main/resources/templates/surveyForm.html
+++ b/src/main/resources/templates/surveyForm.html
@@ -12,6 +12,8 @@
 
 
 <form th:action="@{/survey/new}" th:object="${survey}" method="post">
+    <!-- CSRF Token -->
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
     <label>Survey Title:</label>
     <br>
     <input type="text" th:field="*{title}" required /><br><br>


### PR DESCRIPTION
1. User Registration and Login:
- Registration Page (register.html): Created a form for new users to sign up.
- Login Page (login.html): Developed a custom login form for user authentication.


2. Password Security:
- BCrypt Password Encoder: Used to hash passwords before storing them in the database.

3. SecurityConfig Class:
- Configured authentication and authorization rules.
- Defined which endpoints are publicly accessible and which require authentication.
- Implemented a CustomUserDetailsService to load user-specific data during authentication.

4. CSRF Protection:
- Ensured all forms include CSRF tokens to protect against cross-site request forgery attacks.


5. Roles and Permissions:
- Assigned a default role of ROLE_USER to all authenticated users.
- Restricted access to survey creation and closure endpoints to users with ROLE_USER.


6. Survey Status Update:
- isClosed Field in Survey Entity: Added a boolean field to track the survey's status.
- Close Survey Endpoint: Implemented a POST endpoint (/survey/{id}/close) to allow authenticated survey creators to close their surveys.
- Authorization Checks: Ensured only the survey creator can close their survey by verifying the user's identity.


7. Access Control for Participants: Participation Flow Adjustment:
- Modified the participation endpoint to check if a survey is closed.
- Redirected users to a surveyClosed.html page if they attempt to access a closed survey.


8. User Interface Enhancements:
- Close Survey Button: Added a button on the survey details page (surveyDetails.html) for creators to close their survey.
- Included CSRF tokens in the form for security.
- Survey Status Display: Displayed the survey's status (Open or Closed) on the survey details and listing pages.