### PR TITLE
Fixed survey deletion bug, relates to issue #33 and #34

### DIFF
--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/model/Question.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/model/Question.java
@@ -25,7 +25,7 @@ public class Question {
     @ElementCollection
     private List<String> options = new ArrayList<>();
 
-    @ManyToOne(cascade=CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "survey_id")
     @JsonBackReference
     private Survey survey;

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/model/Survey.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/model/Survey.java
@@ -17,7 +17,7 @@ public class Survey {
 
     private boolean isClosed = false;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "user_id")
     @JsonBackReference
     private User creator;

--- a/src/main/java/com/github/adhambadawi/minisurveymonkey/model/User.java
+++ b/src/main/java/com/github/adhambadawi/minisurveymonkey/model/User.java
@@ -18,7 +18,7 @@ public class User {
     private String role = "ROLE_USER";
 
     @JsonManagedReference
-    @OneToMany(mappedBy = "creator", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "creator", orphanRemoval = true)
     private List<Survey> surveys = new ArrayList<>();
 
     public User() {}


### PR DESCRIPTION
Removed CascadeType.ALL from the @ManyToOne relationships, so that deleting a child entity (like Survey or Question) will not affect the parent entity (User or Survey respectively).
This ensures that when you delete a Survey, only that Survey and its associated Question entities are deleted, not the User or other Survey entities.